### PR TITLE
task_52045_user_management_active_account

### DIFF
--- a/app/assets/stylesheets/admin/custom_admin.scss
+++ b/app/assets/stylesheets/admin/custom_admin.scss
@@ -12,7 +12,8 @@ a {
   }
 }
 
-.delete-icon {
+.delete-icon,
+.inactive-icon {
   color: red;
   margin-right: 5px;
 }
@@ -22,6 +23,18 @@ a {
   margin-left: 5px
 }
 
+.active-icon {
+  color: #5cb85c;
+}
+
 .mg-top-10 {
   margin-top: 10px;
+}
+
+.active {
+  color: #3b913b;
+}
+
+.inactive {
+  color: red
 }

--- a/app/controllers/admin/account_activations_controller.rb
+++ b/app/controllers/admin/account_activations_controller.rb
@@ -1,0 +1,23 @@
+class Admin::AccountActivationsController < Admin::BaseController
+  def edit
+    user = User.find_by id: params[:id]
+    if user && !user.activated?
+      active_user user
+    elsif user&.activated?
+      inactive_user user
+    else
+      flash[:danger] = t ".fail_activated"
+    end
+    redirect_to admin_users_path
+  end
+
+  def active_user user
+    user.activate
+    flash[:success] = t ".success_activated"
+  end
+
+  def inactive_user user
+    user.activate
+    flash[:success] = t ".success_inactivated"
+  end
+end

--- a/app/controllers/admin/static_pages_controller.rb
+++ b/app/controllers/admin/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class Admin::StaticPagesController < Admin::BaseController
-  def index; end
+  def index
+    @pagy, @subject_item = pagy Subject.all, items: Settings.pagy
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,5 @@
+class Admin::UsersController < Admin::BaseController
+  def index
+    @pagy, @user_item = pagy User.user, items: Settings.pagy
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,12 +18,17 @@ class SessionsController < ApplicationController
 
   private
   def handle_log_in user
-    log_in user
-    flash[:success] = t ".login_success"
-    if user.admin?
-      redirect_back_or admin_root_path
+    if user.activated?
+      log_in user
+      flash[:success] = t ".login_success"
+      if user.admin?
+        redirect_back_or admin_root_path
+      else
+        redirect_back_or root_path
+      end
     else
-      redirect_back_or root_path
+      flash[:warning] = t ".account_not_activated"
+      redirect_to root_url
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,6 @@ class UsersController < ApplicationController
   def create
     @user = User.new user_params
     if @user.save
-      log_in @user
       flash[:success] = t "success_signup"
       redirect_to root_path
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,4 +21,16 @@ module ApplicationHelper
     message = object.errors[field].first if object.errors[field].present?
     content_tag(:div, message, class: "text-danger")
   end
+
+  def icon_active_or_inactive user
+    if user.activated
+      "fa-lock fa icon inactive-icon"
+    else
+      "fa fa-unlock icon active-icon"
+    end
+  end
+
+  def status_account user
+    user.activated ? "active" : "inactive"
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,7 +20,7 @@ toastr.options = {
   preventDuplicates: false,
   onclick: null,
   showDuration: "300",
-  hideDuration: "1000",
+  hideDuration: "3000",
   timeOut: "2000",
   extendedTimeOut: "1000",
   showEasing: "swing",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,10 @@ class User < ApplicationRecord
                        length: {minimum: Settings.password_min_length},
                        allow_nil: true
 
+  def activate
+    update activated: !activated, activated_at: Time.zone.now
+  end
+
   private
 
   def downcase_email

--- a/app/views/admin/static_pages/index.html.erb
+++ b/app/views/admin/static_pages/index.html.erb
@@ -1,1 +1,33 @@
-<p>Static page by Admin site</p>
+<% provide(:title, t(".title")) %>
+<h1><%= t ".heading" %></h1>
+<div class="row">
+  <div class="col-md-12">
+    <% if @subject_item.any? %>
+      <table class="table table-striped table-hover">
+        <thead>
+          <tr>
+            <th scope="col"><%= t ".name" %></th>
+            <th scope="col"><%= t ".description" %></th>
+            <th scope="col"><%= t ".total_ques" %></th>
+            <th scope="col"><%= t ".num_created" %></th>
+            <th scope="col"><%= t ".num_passed" %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @subject_item.each do |subject| %>
+            <tr>
+              <td><%= subject.name %></td>
+              <td><%= subject.description %></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%== pagy_bootstrap_nav(@pagy) %>
+    <% else %>
+      <%= t ".no_subject" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,37 @@
+<% provide(:title, t(".title" )) %>
+<h1><%= t ".heading" %></h1>
+<div class="row">
+  <div class="col-md-12">
+    <% if @user_item.any? %>
+      <table class="table table-striped table-hover">
+        <thead>
+          <tr>
+            <th scope="col"><%= t ".name" %></th>
+            <th scope="col"><%= t ".email" %></th>
+            <th scope="col"><%= t ".attended" %></th>
+            <th scope="col"><%= t ".passed" %></th>
+            <th scope="col"><%= t ".action" %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @user_item.each do |user| %>
+            <tr class="<%= status_account(user) %>">
+              <td><%= user.name %></td>
+              <td><%= user.email %></td>
+              <td></td>
+              <td></td>
+              <td>
+                <%= link_to edit_admin_account_activation_path(user.id) do %>
+                  <i class="<%= icon_active_or_inactive(user) %>" aria-hidden="true"></i>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%== pagy_bootstrap_nav(@pagy) %>
+    <% else %>
+      <%= t ".no_user" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_header_admin.html.erb
+++ b/app/views/layouts/_header_admin.html.erb
@@ -13,6 +13,7 @@
             <li><%= link_to t(".en"), locale:"en" %></li>
           </ul>
         </li>
+        <li><%= link_to t(".users"), admin_users_path %></li>
         <li><%= link_to t(".subjects"), admin_subjects_path %></li>
         <li><%= link_to t(".questions"), admin_questions_path %></li>
         <% if logged_in? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   base_title: "Maxe"
   maxe: "maxe"
   maxe_admin: "maxe admin"
-  success_signup: "Welcome to the Maxe App!"
+  success_signup: "Welcome to the Maxe App! Contact the administrator to activate the account"
   not_found: "Not found"
   fail_signup: "Errors occurred. Please try again"
   danger: "Please log in"
@@ -20,6 +20,7 @@ en:
     header_admin:
       login: "Login"
       subjects: "Manage subjects"
+      users: "Manage users"
       languages: "Languages"
       en: "English"
       vi: "Vietnamese"
@@ -53,6 +54,7 @@ en:
     create:
       invalid_email_password_combination: "Invalid email/password combination"
       login_success: "Log in successfully"
+      account_not_activated: "Account not activated. Contact the administrator to activate the account"
   users:
     new:
       signup: "Sign up"
@@ -62,6 +64,30 @@ en:
       update_success: "Profile updated"
       update_false: "Update failed"
   admin:
+    static_pages:
+      index:
+        title: "Home page"
+        heading: "Overview"
+        name: "Subject name"
+        total_ques: "Total number of questions"
+        num_created: "Number of times the test was created"
+        num_passed: "Number of tests passed"
+        description: "Description"
+    users:
+      index:
+        title: "Manage users"
+        heading: "All users"
+        name: "Name"
+        email: "Email"
+        attended: "Attended (subject)"
+        passed: "Passed (subject)"
+        action: "Action"
+        no_user: "No user yet"
+    account_activations:
+      edit:
+        success_activated: "Account activated"
+        success_inactivated: "Disable successfully"
+        fail_activated: "Activation failed"
     profile:
       update:
         update_success: "Profile updated"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -2,7 +2,7 @@ vi:
   base_title: "Maxe"
   maxe: "maxe"
   maxe_admin: "maxe admin"
-  success_signup: "Chào mừng bạn đến với ứng dụng"
+  success_signup: "Chào mừng bạn đến với ứng dụng! Liên hệ quản trị viên để  được kích hoạt tài khoản"
   not_found: "Không tìm thấy"
   fail_signup: "Có lỗi xảy ra. Vui lòng thử lại"
   danger: "Hãy đăng nhập"
@@ -21,6 +21,7 @@ vi:
       login: "Đăng nhập"
       subjects: "Quản lý môn học"
       languages: "Ngôn ngữ"
+      users: "Quản lý người dùng"
       en: "Tiếng Anh"
       vi: "Tiếng Việt"
       account: "Tài khoản"
@@ -53,6 +54,7 @@ vi:
     create:
       invalid_email_password_combination: "Email và password không trùng khớp"
       login_success: "Đăng nhập thành công"
+      account_not_activated: "Tài khoản chưa được kích hoạt. Liên hệ quản trị viên để  được kích hoạt tài khoản"
   users:
     new:
       signup: "Đăng ký"
@@ -62,6 +64,30 @@ vi:
       update_success: "Thông tin đã được thay đổi"
       update_false: "Cập nhật thông tin thất bại"
   admin:
+    static_pages:
+      index:
+        title: "Trang chủ"
+        heading: "Tổng quan"
+        name: "Tên môn học"
+        total_ques: "Tổng số câu hỏi"
+        num_created: "Số bài kiểm tra đã tạo"
+        num_passed: "Số bài kiểm tra đạt"
+        description: "Mô tả"
+    users:
+      index:
+        title: "Quản lý người dùng"
+        heading: "Tất cả người dùng"
+        name: "Tên"
+        email: "Địa chỉ Email"
+        attended: Đã tham gia (môn học)
+        passed: "Đã hoàn thành (môn học)"
+        action: "Hành động"
+        no_user: "Chưa có môn học"
+    account_activations:
+      edit:
+        success_activated: "Kích hoạt tài khoản thành công"
+        success_inactivated: "Vô hiệu hóa tài khoản thành công"
+        fail_activated: "Kích hoạt thất bại"
     profile:
       update:
         update_success: "Thông tin đã được thay đổi"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,15 +4,18 @@ Rails.application.routes.draw do
     resources :subjects, only: %i(index)
     resources :users
     resources :subjects, only: %i(index)
+
     get "/signup", to: "users#new"
     get "/login", to: "sessions#new"
     post "/login", to: "sessions#create"
     delete "/logout", to: "sessions#destroy"
-    
+
     namespace :admin do
       root to: "static_pages#index"
-      resources :static_pages
+      resources :static_pages, only: %i(index)
+      resources :users, only: %i(index)
       resources :profile, only: %i(edit update)
+      resources :account_activations, only: %i(edit)
       resources :subjects, only: %i(index new create edit update destroy)
       resources :questions
       resources :answers

--- a/db/migrate/20220817020146_add_activated_to_users.rb
+++ b/db/migrate/20220817020146_add_activated_to_users.rb
@@ -1,0 +1,6 @@
+class AddActivatedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_16_061746) do
+ActiveRecord::Schema.define(version: 2022_08_17_020146) do
 
   create_table "answers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "content"
@@ -50,6 +50,8 @@ ActiveRecord::Schema.define(version: 2022_08_16_061746) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
     t.integer "role_id", default: 0
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## Related Tickets
- [##52045](https://edu-redmine.sun-asterisk.vn/issues/52045)

## WHAT (optional)
- Change number items `completed/total` in admin page.

## HOW
- Hiển thị danh sách người dùng
- Admin có thể kích hoạt hoặc vô hiệu hóa tài khoản đó
- Người dùng đăng ký thành công nhưng chưa được kích hoạt thì vẫn chưa để đăng nhập vào hệ thống

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
![image](https://user-images.githubusercontent.com/109218665/185046748-9a44adb1-9000-4696-ba14-ac20a021e67f.png)
